### PR TITLE
Add Crash Bandicoot memory card corruption story

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,5 @@ Debugging stories are fun! This is a collection of links to various debugging st
 [Veeerrry Slow Logons](http://blogs.technet.com/b/markrussinovich/archive/2012/07/02/3506849.aspx)
 
 [Debugging Behind the Iron Curtain](http://jakepoz.com/soviet_debugging.html)
+
+[Crash Bandicoot Memory Card Corruption](http://www.gamasutra.com/blogs/DaveBaggett/20131031/203788/My_Hardest_Bug_Ever.php)


### PR DESCRIPTION
I would have added this to the last PR but I couldn't recall where to find it until now.

In short, developer on the Crash Bandicoot PS1 game describes a hardware bug in which crosstalk among the timer crystal, memory card baud rate controller, and game controller caused memory card corruption during a save.
