### PR TITLE
Add a story about random number collision

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Debugging stories are fun! This is a collection of links to various debugging st
 
 [Email only goes 500 miles](http://www.ibiblio.org/harris/500milemail.html)
 
+[Impossible random number collision happened in practice](https://medium.com/@betable/tifu-by-using-math-random-f1c308c4fd9d)
+
 [Incorrect sign masking operation](https://labs.spotify.com/2015/08/27/underflow-bug/)
 
 [iOS file corruption](https://code.facebook.com/posts/313033472212144/debugging-file-corruption-on-ios/)


### PR DESCRIPTION
An interesting story from Betable developers. They assign a random identifier to each API request, each identifier being a randomly generated 22-character string. The probability for duplicate identifiers should have been almost zero, but they eventually discovered that duplicate identifiers had indeed been generated. They had to look into the RNG implementation in the V8 JavaScript engine to find the cause.