### PR TITLE
Added OpenOffice/Ubuntu file bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ Debugging stories are fun! This is a collection of links to various debugging st
 
 [Node.js memory leak](https://www.joyent.com/blog/walmart-node-js-memory-leak)
 
+[OpenOffice + Ubuntu|2009-04-28](https://bugs.launchpad.net/ubuntu/+source/cupsys/+bug/255161/comments/28) - "My wife has complained that OpenOffice will never print on Tuesdays" (bug is actually with the [file utility](https://bugs.launchpad.net/ubuntu/+source/file/+bug/248619)
+
+
 [OS crashes on boot if machine was used recently](http://blog.valerieaurora.org/2013/12/17/heres-my-favorite-operating-systems-war-story-whats-yours/)
 
 [PDP-11 crashes only when live cattle are being shipped from northern Ukraine and western Russia](http://www.jakepoz.com/debugging-behind-the-iron-curtain/)


### PR DESCRIPTION
The earlier (and actual) bug report regards the __file__ utility, but I like the OpenOffice report as an example of how such a bug manifests itself to the end user. Most engineers when hearing the OpenOffice report would think "That can't possibly be right!" but how do you get to the root cause?