### PR TITLE
fixed URL for "Perl can't read from TMPDIR"

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Debugging stories are fun! This is a collection of links to various debugging st
 
 [PDP-11 crashes only when live cattle are being shipped from northern Ukraine and western Russia](http://www.jakepoz.com/debugging-behind-the-iron-curtain/)
 
-[Perl can't read from TMPDIR?](https://blog.afoolishmanifesto.com/posts/investigation-into-why-perl-cant-read-from-TMPDIR/) [(separate analysis of the same issue here)](http://blog.plover.com/tech/tmpdir.html)
+[Perl can't read from TMPDIR?](https://blog.afoolishmanifesto.com/posts/investigation-into-why-perl-cant-read-from-tmpdir/) [(separate analysis of the same issue here)](http://blog.plover.com/tech/tmpdir.html)
 
 [Polish S doesn't appear on medium](https://medium.com/medium-eng/the-curious-case-of-disappearing-polish-s-fa398313d4df)
 


### PR DESCRIPTION
The URL for "PERL can't read from TMPDIR" has changed from

https://blog.afoolishmanifesto.com/posts/investigation-into-why-perl-cant-read-from-TMPDIR/

to 

https://blog.afoolishmanifesto.com/posts/investigation-into-why-perl-cant-read-from-tmpdir/

… and so should to be fixed. This PR does exactly that.