### PR TITLE
Updated dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Debugging stories are fun! This is a collection of links to various debugging st
 
 [Breakpoint takes 15ms](http://blog.jwhitham.org/2015/04/the-mystery-of-fifteen-millisecond.html)
 
-[Bug that hides from breakpoints](http://www.drewdevault.com/2014/02/02/The-worst-bugs.html)
+[Bug that hides from breakpoints](https://sircmpwn.github.io/2014/02/02/The-worst-bugs.html)
 
 [C64 Variable Screen Position crash](http://www.linusakesson.net/scene/safevsp/index.php)
 
@@ -130,6 +130,7 @@ Debugging stories are fun! This is a collection of links to various debugging st
 * Ramon Fried
 * Sean Cassidy
 * James Porter
+* Brett Miller (WrathZA)
 
 ## TODOs:
 


### PR DESCRIPTION
http://www.drewdevault.com/2014/02/02/The-worst-bugs.html 
replaced with https://sircmpwn.github.io/2014/02/02/The-worst-bugs.html
as the original is a dead link