### PR TITLE
Fix 404 for "The Case of the Veeerrry Slow Logons"

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Debugging stories are fun! This is a collection of links to various debugging st
 
 [Signal handling on 286 emulator for Xenix](https://news.ycombinator.com/item?id=7684827)
 
-[The Case of Veeerrry Slow Logons](https://docs.microsoft.com/en-us/archive/blogs/markrussinovich/the-case-of-the-veeerrry-slow-logons)
+[The Case of Veeerrry Slow Logons](https://techcommunity.microsoft.com/t5/windows-blog-archive/the-case-of-the-veeerrry-slow-logons/ba-p/724275)
 
 [SSH sometimes fails from cron](http://mina.naguib.ca/blog/2012/10/22/the-little-ssh-that-sometimes-couldnt.html)
 


### PR DESCRIPTION
The current link redirects to https://docs.microsoft.com/en-us/archive/blogs/content-removed , but a bit of googling suggests that the post has moved here: https://techcommunity.microsoft.com/t5/windows-blog-archive/the-case-of-the-veeerrry-slow-logons/ba-p/724275